### PR TITLE
update rules_closure to 0.8.0 to fix bazel 0.19.2 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,3 @@ matrix:
   fast_finish: true
   allow_failures:
   - os: osx # currently fails on //examples/helloworld/cpp:test
-  - env: V=0.19.2

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,12 +25,14 @@ go_register_toolchains()
 # ================================================================
 
 
-github_archive(
+http_archive(
     name = "io_bazel_rules_closure",
-    commit = "21b757480a1e3a67f1a25a8f27a404fc751e1477", # 0.6.0
-    org = "bazelbuild",
-    repo = "rules_closure",
-    sha256 = "84687d2bc01fe2a0b45ec906bee87c5d336767e00d8cc8d40236c8804d5d5ced",
+    sha256 = "b29a8bc2cb10513c864cb1084d6f38613ef14a143797cea0af0f91cd385f5e8c",
+    strip_prefix = "rules_closure-0.8.0",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/0.8.0.tar.gz",
+        "https://github.com/bazelbuild/rules_closure/archive/0.8.0.tar.gz",
+    ],
 )
 
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_repositories")


### PR DESCRIPTION
- Bazel 0.18.0+ embeds JDK 9
- current rules_closure does not work with JDK 9
- rules_closure to 0.8.0 (latest release) supports JDK 9