### PR TITLE
rename com_google_grpc -> com_github_grpc_grpc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,14 +7,14 @@ changed that may break your build (for example, string references such
 as 'external/com_github_google_protobuf/src' should be migrated to
 'external/com_google_protobuf/src' in an 'imports' attribute).
 
-* Introduce cpp/grpc_repository.bzl to setup a custom @com_google_grpc
+* Introduce cpp/grpc_repository.bzl to setup a custom @com_github_grpc_grpc
   external workspace (no longer using git_repository#init_submodules).
-  This pulls down grpc/grpc from github as @com_google_grpc_base, sets
-  up a mirrored external workspace in @com_google_grpc that symlinks
-  to @com_google_grpc_base, then does a "git submodule the hard way" for
+  This pulls down grpc/grpc from github as @com_github_grpc_grpc_base, sets
+  up a mirrored external workspace in @com_github_grpc_grpc that symlinks
+  to @com_github_grpc_grpc_base, then does a "git submodule the hard way" for
   c-ares, and installs a patched version of generate_cc.bzl.
 * Rename repository @com_github_google_protobuf to @com_google_protobuf.
-* Rename repository @com_github_grpc_grpc to @com_google_grpc.
+* Rename repository @com_github_grpc_grpc to @com_github_grpc_grpc.
 * Rename repository @gtest to @com_google_googletest.
 * Updated grpc/grpc to 1.6.1.
 * Updated madler/zlib to 1.2.11.

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -16,15 +16,15 @@ To update this list, `bazel build @org_pubref_rules_protobuf//:deps && cp bazel-
 
 | Rule | Workspace | Detail |
 | ---: | :--- | :--- |
-| grpc_archive | **`@com_google_grpc`** |  |
+| grpc_archive | **`@com_github_grpc_grpc`** |  |
 | [http_archive](https://docs.bazel.build/versions/master/be/workspace.html#http_archive) | **`@boringssl`** | [(no hash provided)](https://boringssl.googlesource.com/boringssl/+archive/886e7d75368e3f4fab3f4d0d3584e4abfc557755.tar.gz) |
 | [bind](https://docs.bazel.build/versions/master/be/workspace.html#bind) | **`@libssl`** | `//external:libssl` (`@boringssl//:ssl`) |
 | [http_archive](https://docs.bazel.build/versions/master/be/workspace.html#http_archive) | **`@com_github_madler_zlib`** | [sha256:1cce3828ec2b](https://github.com/madler/zlib/archive/cacf7f1d4e3d44d871b605da3b647f07d718623f.zip) |
 | [http_archive](https://docs.bazel.build/versions/master/be/workspace.html#http_archive) | **`@com_github_cares_cares`** | [sha256:932bf7e593d4](https://github.com/c-ares/c-ares/archive/3be1924221e1326df520f8498d704a5c4c8d0cce.zip) |
 | [bind](https://docs.bazel.build/versions/master/be/workspace.html#bind) | **`@cares`** | `//external:cares` (`@com_github_cares_cares//:ares`) |
 | [bind](https://docs.bazel.build/versions/master/be/workspace.html#bind) | **`@zlib`** | `//external:zlib` (`@com_github_madler_zlib//:zlib`) |
-| [bind](https://docs.bazel.build/versions/master/be/workspace.html#bind) | **`@nanopb`** | `//external:nanopb` (`@com_google_grpc//third_party/nanopb`) |
-| [bind](https://docs.bazel.build/versions/master/be/workspace.html#bind) | **`@protoc_gen_grpc_cpp`** | `//external:protoc_gen_grpc_cpp` (`@com_google_grpc//:grpc_cpp_plugin`) |
+| [bind](https://docs.bazel.build/versions/master/be/workspace.html#bind) | **`@nanopb`** | `//external:nanopb` (`@com_github_grpc_grpc//third_party/nanopb`) |
+| [bind](https://docs.bazel.build/versions/master/be/workspace.html#bind) | **`@protoc_gen_grpc_cpp`** | `//external:protoc_gen_grpc_cpp` (`@com_github_grpc_grpc//:grpc_cpp_plugin`) |
 | [http_archive](https://docs.bazel.build/versions/master/be/workspace.html#http_archive) | **`@com_google_googletest`** | [sha256:f87029f64727](https://github.com/google/googletest/archive/7c6353d29a147cad1c904bf2957fd4ca2befe135.zip) |
 
 ## Java
@@ -99,6 +99,6 @@ To update this list, `bazel build @org_pubref_rules_protobuf//:deps && cp bazel-
 
 | Rule | Workspace | Detail |
 | ---: | :--- | :--- |
-| [bind](https://docs.bazel.build/versions/master/be/workspace.html#bind) | **`@protoc_gen_grpc_node`** | `//external:protoc_gen_grpc_node` (`@com_google_grpc//:grpc_node_plugin`) |
+| [bind](https://docs.bazel.build/versions/master/be/workspace.html#bind) | **`@protoc_gen_grpc_node`** | `//external:protoc_gen_grpc_node` (`@com_github_grpc_grpc//:grpc_node_plugin`) |
 | [npm_repository](https://github.com/pubref/rules_node#npm_repository) | **`@npm_protobuf_stack`** | [async@2.6.0](https://npmjs.org/package/async), [google-protobuf@3.5.0](https://npmjs.org/package/google-protobuf), [lodash@4.17.5](https://npmjs.org/package/lodash), [minimist@1.2.0](https://npmjs.org/package/minimist) |
 | [npm_repository](https://github.com/pubref/rules_node#npm_repository) | **`@npm_grpc`** | [grpc@1.0.0](https://npmjs.org/package/grpc) |

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -5,8 +5,8 @@ load("//protobuf:rules.bzl", "proto_language")
 proto_language(
     name = "cpp",
     grpc_compile_deps = [
-        "@com_google_grpc//:grpc++",
-        "@com_google_grpc//:grpc++_reflection",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_github_grpc_grpc//:grpc++_reflection",
     ],
     grpc_file_extensions = [
         ".grpc.pb.h",

--- a/cpp/deps.bzl
+++ b/cpp/deps.bzl
@@ -2,7 +2,7 @@ CARES_VERSION = "3be1924221e1326df520f8498d704a5c4c8d0cce" # Jun 16, 2017 (1.13.
 
 DEPS = {
 
-    "com_google_grpc": {
+    "com_github_grpc_grpc": {
         "rule": "grpc_archive",
         "url": "https://github.com/grpc/grpc/archive/66b9770a8ad326c1ee0dbedc5a8f32a52a604567.tar.gz", # 1.10.1
         "sha256": "14c1d63217f829f3c23bf039a76c186d0886c5b5c64e7eced44764f0fc564e6a",
@@ -38,14 +38,14 @@ DEPS = {
         "strip_prefix": "c-ares-" + CARES_VERSION,
         "build_file": str(Label("//protobuf:build_file/cares.BUILD")),
     },
-    
+
     # grpc++ expects //external:cares
     "cares": {
         "rule": "bind",
         "actual": "@com_github_cares_cares//:ares",
     },
 
-    
+
     # grpc++ expects //external:zlib
     "zlib": {
         "rule": "bind",
@@ -55,7 +55,7 @@ DEPS = {
     # grpc++ expects //external:nanopb
     "nanopb": {
         "rule": "bind",
-        "actual": "@com_google_grpc//third_party/nanopb",
+        "actual": "@com_github_grpc_grpc//third_party/nanopb",
     },
 
     # Bind the executable cc_binary grpc plugin into
@@ -64,7 +64,7 @@ DEPS = {
     # bind it in external?
     "protoc_gen_grpc_cpp": {
         "rule": "bind",
-        "actual": "@com_google_grpc//:grpc_cpp_plugin",
+        "actual": "@com_github_grpc_grpc//:grpc_cpp_plugin",
     },
 
     # GTest is for our own internal cc tests.

--- a/cpp/generate_cc.bzl
+++ b/cpp/generate_cc.bzl
@@ -4,7 +4,7 @@ This is an internal rule used by cc_grpc_library, and shouldn't be used
 directly.
 
 This file becomes symlinked to replace the original
-@com_google_grpc//bazel/generate_cc.bzl, which does not seem to work
+@com_github_grpc_grpc//bazel/generate_cc.bzl, which does not seem to work
 out of the box.  IF YOU UPDATE TO A NEWER VERSION OF GRPC/GRPC, THERE
 MAY BE CHANGES TO THAT FILE WHICH MIGHT EITHER BREAK THIS OR MAKE IT
 OBSOLETE.
@@ -23,7 +23,7 @@ two lengths.
 The second change is that we need protoc to evaluate within the
 context of the workspace_root rather than the execroot.  To do this,
 we shift into the external workspace with a 'cd
-external/com_google_grpc', and adjust dir_out, plugin_out,
+external/com_github_grpc_grpc', and adjust dir_out, plugin_out,
 cpp_out etc to be relative to the forward shifted position.
 
 Third change: Windows compatibility by not including : when unnecessary.

--- a/cpp/grpc_archive.bzl
+++ b/cpp/grpc_archive.bzl
@@ -21,9 +21,9 @@ def _grpc_archive_impl(rtx):
     )
 
     _execute(rtx, ["rm", "bazel/generate_cc.bzl"])
-    
+
     rtx.symlink(rtx.path(rtx.attr.generate_cc_bzl), "bazel/generate_cc.bzl")
-    rtx.file("WORKSPACE", "workspace(name = 'com_google_grpc')")
+    rtx.file("WORKSPACE", "workspace(name = 'com_github_grpc_grpc')")
 
 # Http archive that patches the grpc repository so that the reflection++ targets compile
 # as an external workspace.

--- a/cpp/rules.bzl
+++ b/cpp/rules.bzl
@@ -5,7 +5,7 @@ load("//cpp:grpc_archive.bzl", "grpc_archive")
 def cpp_proto_repositories(
     lang_deps = DEPS,
     lang_requires = [
-      "com_google_grpc",
+      "com_github_grpc_grpc",
       "com_github_cares_cares",
       "com_google_googletest",
       "com_github_madler_zlib",
@@ -33,8 +33,8 @@ PB_COMPILE_DEPS = [
 ]
 
 GRPC_COMPILE_DEPS = PB_COMPILE_DEPS + [
-    "@com_google_grpc//:grpc++",
-    "@com_google_grpc//:grpc++_reflection",
+    "@com_github_grpc_grpc//:grpc++",
+    "@com_github_grpc_grpc//:grpc++_reflection",
 ]
 
 def cpp_proto_compile(langs = [str(Label("//cpp"))], **kwargs):

--- a/node/BUILD
+++ b/node/BUILD
@@ -5,7 +5,7 @@ load("//protobuf:rules.bzl", "proto_language")
 proto_language(
     name = "node",
     grpc_file_extensions = ["_grpc_pb.js"],
-    grpc_plugin = "@com_google_grpc//:grpc_node_plugin",
+    grpc_plugin = "@com_github_grpc_grpc//:grpc_node_plugin",
     grpc_plugin_name = "grpc_node",
     pb_file_extensions = ["_pb.js"],
     pb_options = [

--- a/node/deps.bzl
+++ b/node/deps.bzl
@@ -2,7 +2,7 @@ DEPS = {
 
     "protoc_gen_grpc_node": {
         "rule": "bind",
-        "actual": "@com_google_grpc//:grpc_node_plugin",
+        "actual": "@com_github_grpc_grpc//:grpc_node_plugin",
     },
 
     "npm_protobuf_stack": {

--- a/objc/deps.bzl
+++ b/objc/deps.bzl
@@ -2,7 +2,7 @@ DEPS = {
 
     "protoc_gen_grpc_objc": {
         "rule": "bind",
-        "actual": "@com_google_grpc//:grpc_objective_c_plugin",
+        "actual": "@com_github_grpc_grpc//:grpc_objective_c_plugin",
     },
 
 }

--- a/objc/rules.bzl
+++ b/objc/rules.bzl
@@ -21,7 +21,7 @@ PB_COMPILE_DEPS = [
 ]
 
 GRPC_COMPILE_DEPS = PB_COMPILE_DEPS + [
-    "@com_google_grpc//:grpc_objc",
+    "@com_github_grpc_grpc//:grpc_objc",
 ]
 
 def objc_proto_compile(langs = [str(Label("//objc"))], **kwargs):

--- a/protobuf/build_file/cares.BUILD
+++ b/protobuf/build_file/cares.BUILD
@@ -1,5 +1,5 @@
 # This is an exact copy of grpc/grpc/third_party/cares.BUILD
-# s/com_google_grpc/com_google_grpc/g.
+# s/com_github_grpc_grpc/com_github_grpc_grpc/g.
 # Why?  Here the github_grpc_grpc repo is built last
 # and would becomes a circular dependency.
 
@@ -41,7 +41,7 @@ config_setting(
 
 genrule(
     name = "ares_build_h",
-    srcs = ["@com_google_grpc//third_party/cares:ares_build.h"],
+    srcs = ["@com_github_grpc_grpc//third_party/cares:ares_build.h"],
     outs = ["ares_build.h"],
     cmd = "cat $< > $@",
 )
@@ -49,13 +49,13 @@ genrule(
 genrule(
     name = "ares_config_h",
     srcs = select({
-        ":ios_x86_64": ["@com_google_grpc//third_party/cares:config_darwin/ares_config.h"],
-        ":ios_armv7": ["@com_google_grpc//third_party/cares:config_darwin/ares_config.h"],
-        ":ios_armv7s": ["@com_google_grpc//third_party/cares:config_darwin/ares_config.h"],
-        ":ios_arm64": ["@com_google_grpc//third_party/cares:config_darwin/ares_config.h"],
-        ":darwin": ["@com_google_grpc//third_party/cares:config_darwin/ares_config.h"],
-        ":android": ["@com_google_grpc//third_party/cares:config_android/ares_config.h"],
-        "//conditions:default": ["@com_google_grpc//third_party/cares:config_linux/ares_config.h"],
+        ":ios_x86_64": ["@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h"],
+        ":ios_armv7": ["@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h"],
+        ":ios_armv7s": ["@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h"],
+        ":ios_arm64": ["@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h"],
+        ":darwin": ["@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h"],
+        ":android": ["@com_github_grpc_grpc//third_party/cares:config_android/ares_config.h"],
+        "//conditions:default": ["@com_github_grpc_grpc//third_party/cares:config_linux/ares_config.h"],
     }),
     outs = ["ares_config.h"],
     cmd = "cat $< > $@",

--- a/python/deps.bzl
+++ b/python/deps.bzl
@@ -2,12 +2,12 @@ DEPS = {
 
     "protoc_gen_grpc_python": {
         "rule": "bind",
-        "actual": "@com_google_grpc//:grpc_python_plugin",
+        "actual": "@com_github_grpc_grpc//:grpc_python_plugin",
     },
 
     "grpcio": {
         "rule": "bind",
-        "actual": "@com_google_grpc//:grpc_python_plugin",
+        "actual": "@com_github_grpc_grpc//:grpc_python_plugin",
     },
 
 }

--- a/ruby/deps.bzl
+++ b/ruby/deps.bzl
@@ -2,7 +2,7 @@ DEPS = {
 
     "protoc_gen_grpc_ruby": {
         "rule": "bind",
-        "actual": "@com_google_grpc//:grpc_ruby_plugin",
+        "actual": "@com_github_grpc_grpc//:grpc_ruby_plugin",
     },
 
 }


### PR DESCRIPTION
Unfortunately due to the age of this, I don't actually remember why this was needed. I suspect it's due to being in line with other repos that might import the repo so that they can override each other properly...