### PR TITLE
[skip ci] run travis only on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,7 @@ notifications:
 
 matrix:
   fast_finish: true
+
+branches:
+  only:
+  - master

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://github.com/stackb/rules_proto
 ---
 
 
-# `rules_protobuf` [![Build Status](https://travis-ci.org/pubref/rules_protobuf.svg?branch=master)](https://travis-ci.org/pubref/rules_protobuf)
+# `rules_protobuf` [![Build Status](https://travis-ci.org/vsco/rules_protobuf.svg?branch=master)](https://travis-ci.org/vsco/rules_protobuf)
 
 Bazel skylark rules for building [protocol buffers][protobuf-home]
 with +/- gRPC support on (osx, linux) :sparkles:.
@@ -92,7 +92,7 @@ of this project are to:
 If you have not already installed `bazel` on your workstation, follow
 the [bazel instructions][bazel-install].
 
-> NOTE: Bazel 0.8.0 or above is required for go support. 
+> NOTE: Bazel 0.8.0 or above is required for go support.
 
 ## 2. Add rules_protobuf your WORKSPACE
 


### PR DESCRIPTION
Right now, we're not triggering builds on master merges because PR on push is disabled. I want to enable this again, but allow on master only.