### PR TITLE
stop using native http rules

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//protobuf:rules.bzl", "proto_language", "proto_language_deps")
+load("//protobuf:rules.bzl", "proto_language")
 load("//java:rules.bzl", "java_proto_language_import")
 
 proto_language(

--- a/java/deps.bzl
+++ b/java/deps.bzl
@@ -20,19 +20,19 @@ DEPS = {
 
     "protoc_gen_grpc_java_linux_x86_64": {
         "rule": "http_file",
-        "url": "https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.9.0/protoc-gen-grpc-java-1.9.0-linux-x86_64.exe",
+        "urls": ["https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.9.0/protoc-gen-grpc-java-1.9.0-linux-x86_64.exe"],
         "sha256": "f20cc8c052eea904c5a979c140237696e3f187f35deac49cd70b16dc0635f463",
     },
 
     "protoc_gen_grpc_java_macosx": {
         "rule": "http_file",
-        "url": "http://central.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.9.0/protoc-gen-grpc-java-1.9.0-osx-x86_64.exe",
+        "urls": ["http://central.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.9.0/protoc-gen-grpc-java-1.9.0-osx-x86_64.exe"],
         "sha256": "593937361f99e8b145fe29c78c71cdd00e8327ae88de010729479eb2acdc1de9",
     },
 
     "protoc_gen_grpc_java_windows_x86_64": {
         "rule": "http_file",
-        "url": "https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.9.0/protoc-gen-grpc-java-1.9.0-windows-x86_64.exe",
+        "urls": ["https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.9.0/protoc-gen-grpc-java-1.9.0-windows-x86_64.exe"],
         "sha256": "28ee62f58f14fa1d33666e02c2c9dcca77ea98427446543c0ba00b7ea597d292",
     },
 

--- a/java/grpc-java-maven-deps/WORKSPACE
+++ b/java/grpc-java-maven-deps/WORKSPACE
@@ -1,11 +1,13 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 # Note: This is a utility workspace (probably does not belong in
 # tests) to help compute the transitive deps of grpc-java.
 
 http_archive(
     name = "org_pubref_rules_maven",
-    url = "https://github.com/pubref/rules_maven/archive/43d56ae584ffdf1cd79307728bfd2436c475d35e.zip",
-    sha256 = "33053be697be119582ae294504d8857b76e6ffa6ebadffc76d644854a504af43",
-    strip_prefix = "rules_maven-43d56ae584ffdf1cd79307728bfd2436c475d35e",
+    url = "https://github.com/pubref/rules_maven/archive/25214e11ef391bd2dc08cad3a5637ceac93b0769.zip",
+    sha256 = "8bbb374af3971fa8be2a853c9d37d148cde76186ce1f19833f9bb3d5c201a581",
+    strip_prefix = "rules_maven-25214e11ef391bd2dc08cad3a5637ceac93b0769",
 )
 
 load("@org_pubref_rules_maven//maven:rules.bzl", "maven_repositories", "maven_repository")

--- a/protobuf/internal/github_archive.bzl
+++ b/protobuf/internal/github_archive.bzl
@@ -1,3 +1,5 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 def github_archive(name, org, repo, commit, **kwargs):
     url = "https://github.com/{org}/{repo}/archive/{commit}.zip".format(
         org = org,
@@ -8,13 +10,7 @@ def github_archive(name, org, repo, commit, **kwargs):
         repo = repo,
         commit = commit,
     )
-    if "build_file" in kwargs or "build_file_content" in kwargs:
-        native.new_http_archive(name = name,
-                                url = url,
-                                strip_prefix = strip_prefix,
-                                **kwargs)
-    else:
-        native.http_archive(name = name,
-                            url = url,
-                            strip_prefix = strip_prefix,
-                            **kwargs)
+    http_archive(name = name,
+                 url = url,
+                 strip_prefix = strip_prefix,
+                 **kwargs)

--- a/protobuf/internal/require.bzl
+++ b/protobuf/internal/require.bzl
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 def _needs_install(name, dep, hkeys=["sha256", "sha1", "tag"], verbose=0, strict=False):
 
@@ -55,6 +55,10 @@ def _install(deps, verbose, strict):
             fail("Missing attribute 'rule': %s" % name)
         if rule == "http_archive" or rule == "new_http_archive":
             rule = http_archive
+            if verbose: print("Loading %s)" % name)
+            rule(**d)
+        elif rule == "http_file":
+            rule = http_file
             if verbose: print("Loading %s)" % name)
             rule(**d)
         elif hasattr(native, rule):

--- a/protobuf/internal/require.bzl
+++ b/protobuf/internal/require.bzl
@@ -1,3 +1,5 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 def _needs_install(name, dep, hkeys=["sha256", "sha1", "tag"], verbose=0, strict=False):
 
     # Does it already exist?
@@ -51,7 +53,11 @@ def _install(deps, verbose, strict):
         rule = d.pop("rule", None)
         if not rule:
             fail("Missing attribute 'rule': %s" % name)
-        if hasattr(native, rule):
+        if rule == "http_archive" or rule == "new_http_archive":
+            rule = http_archive
+            if verbose: print("Loading %s)" % name)
+            rule(**d)
+        elif hasattr(native, rule):
             rule = getattr(native, rule)
             if verbose: print("Loading %s)" % name)
             rule(**d)


### PR DESCRIPTION
Bazel deprecated native http rules in favor of replacements in skylark extensions. We need to migrate to them in order to support newer versions of Bazel.

related: https://github.com/pubref/rules_protobuf/issues/253