### PR TITLE
remove some incompatible flags for Bazel 0.25.2

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,6 @@
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
-build --incompatible_disable_legacy_cc_provider=false
 
 query --noincompatible_no_transitive_loads
 query --noincompatible_bzl_disallow_load_after_statement

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,3 @@
-build --incompatible_disallow_legacy_py_provider=false
 build --incompatible_disable_legacy_crosstool_fields=false
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,12 +1,9 @@
-build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
 
-query --noincompatible_no_transitive_loads
 query --noincompatible_bzl_disallow_load_after_statement
 query --noincompatible_disallow_load_labels_to_cross_package_boundaries
 
-sync --noincompatible_no_transitive_loads
 sync --noincompatible_bzl_disallow_load_after_statement
 sync --noincompatible_disallow_load_labels_to_cross_package_boundaries
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,6 @@
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
-build --incompatible_disable_crosstool_file=false
 build --incompatible_disable_legacy_cc_provider=false
 build --incompatible_disable_genrule_cc_toolchain_dependency=false
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,3 @@
-build --incompatible_disable_legacy_crosstool_fields=false
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false

--- a/.bazelrc
+++ b/.bazelrc
@@ -2,7 +2,6 @@ build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
 build --incompatible_disable_legacy_cc_provider=false
-build --incompatible_disable_genrule_cc_toolchain_dependency=false
 
 query --noincompatible_no_transitive_loads
 query --noincompatible_bzl_disallow_load_after_statement

--- a/closure/rules.bzl
+++ b/closure/rules.bzl
@@ -1,7 +1,9 @@
-load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_library")
+load("@io_bazel_rules_closure//closure:defs.bzl", _closure_js_library = "closure_js_library")
 load("//protobuf:rules.bzl",
      "proto_compile",
      "proto_repositories")
+
+closure_js_library = _closure_js_library
 
 def closure_proto_repositories(
     lang_requires = [

--- a/cpp/deps.bzl
+++ b/cpp/deps.bzl
@@ -13,7 +13,8 @@ DEPS = {
         "rule": "http_archive",
         # master-with-bazel Fri Sep 01 15:09:13 2017 +0000
         "url": "https://boringssl.googlesource.com/boringssl/+archive/886e7d75368e3f4fab3f4d0d3584e4abfc557755.tar.gz",
-        "sha256": "033c0fd17f818aa9eb999f684337a058d0e845c812eded857ae3eabb071498de",
+        # don't attempt to checksum this as it does not appear to be stable
+        # "sha256": "",
     },
 
     # libssl is required for c++ grpc where it is expected in

--- a/cpp/deps.bzl
+++ b/cpp/deps.bzl
@@ -13,7 +13,7 @@ DEPS = {
         "rule": "http_archive",
         # master-with-bazel Fri Sep 01 15:09:13 2017 +0000
         "url": "https://boringssl.googlesource.com/boringssl/+archive/886e7d75368e3f4fab3f4d0d3584e4abfc557755.tar.gz",
-        "sha256": "41e91f93cba2a07a7e237933cdda738b604bcfcb2b44b5f9f583459773207ca6",
+        "sha256": "033c0fd17f818aa9eb999f684337a058d0e845c812eded857ae3eabb071498de",
     },
 
     # libssl is required for c++ grpc where it is expected in

--- a/cpp/deps.bzl
+++ b/cpp/deps.bzl
@@ -13,6 +13,7 @@ DEPS = {
         "rule": "http_archive",
         # master-with-bazel Fri Sep 01 15:09:13 2017 +0000
         "url": "https://boringssl.googlesource.com/boringssl/+archive/886e7d75368e3f4fab3f4d0d3584e4abfc557755.tar.gz",
+        "sha256": "41e91f93cba2a07a7e237933cdda738b604bcfcb2b44b5f9f583459773207ca6",
     },
 
     # libssl is required for c++ grpc where it is expected in

--- a/java/grpc-java-maven-deps/.bazelrc
+++ b/java/grpc-java-maven-deps/.bazelrc
@@ -1,7 +1,6 @@
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
-build --incompatible_disable_legacy_cc_provider=false
 
 query --noincompatible_no_transitive_loads
 query --noincompatible_bzl_disallow_load_after_statement

--- a/java/grpc-java-maven-deps/.bazelrc
+++ b/java/grpc-java-maven-deps/.bazelrc
@@ -1,4 +1,3 @@
-build --incompatible_disallow_legacy_py_provider=false
 build --incompatible_disable_legacy_crosstool_fields=false
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false

--- a/java/grpc-java-maven-deps/.bazelrc
+++ b/java/grpc-java-maven-deps/.bazelrc
@@ -1,12 +1,9 @@
-build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
 
-query --noincompatible_no_transitive_loads
 query --noincompatible_bzl_disallow_load_after_statement
 query --noincompatible_disallow_load_labels_to_cross_package_boundaries
 
-sync --noincompatible_no_transitive_loads
 sync --noincompatible_bzl_disallow_load_after_statement
 sync --noincompatible_disallow_load_labels_to_cross_package_boundaries
 

--- a/java/grpc-java-maven-deps/.bazelrc
+++ b/java/grpc-java-maven-deps/.bazelrc
@@ -1,7 +1,6 @@
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
-build --incompatible_disable_crosstool_file=false
 build --incompatible_disable_legacy_cc_provider=false
 build --incompatible_disable_genrule_cc_toolchain_dependency=false
 

--- a/java/grpc-java-maven-deps/.bazelrc
+++ b/java/grpc-java-maven-deps/.bazelrc
@@ -1,4 +1,3 @@
-build --incompatible_disable_legacy_crosstool_fields=false
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false

--- a/java/grpc-java-maven-deps/.bazelrc
+++ b/java/grpc-java-maven-deps/.bazelrc
@@ -2,7 +2,6 @@ build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
 build --incompatible_disable_legacy_cc_provider=false
-build --incompatible_disable_genrule_cc_toolchain_dependency=false
 
 query --noincompatible_no_transitive_loads
 query --noincompatible_bzl_disallow_load_after_statement

--- a/protobuf/rules.bzl
+++ b/protobuf/rules.bzl
@@ -1,6 +1,14 @@
-load("//protobuf:internal/proto_compile.bzl", "proto_compile")
-load("//protobuf:internal/proto_language.bzl", "proto_language", "proto_language_deps")
-load("//protobuf:internal/proto_repositories.bzl", "proto_repositories")
-load("//protobuf:internal/github_archive.bzl", "github_archive")
-load("//protobuf:internal/proto_http_archive.bzl", "proto_http_archive")
-load("//protobuf:internal/proto_dependencies.bzl", "proto_dependencies")
+load("//protobuf:internal/proto_compile.bzl", _proto_compile = "proto_compile")
+load("//protobuf:internal/proto_language.bzl", _proto_language = "proto_language", _proto_language_deps = "proto_language_deps")
+load("//protobuf:internal/proto_repositories.bzl", _proto_repositories = "proto_repositories")
+load("//protobuf:internal/github_archive.bzl", _github_archive = "github_archive")
+load("//protobuf:internal/proto_http_archive.bzl", _proto_http_archive = "proto_http_archive")
+load("//protobuf:internal/proto_dependencies.bzl", _proto_dependencies = "proto_dependencies")
+
+proto_compile = _proto_compile
+proto_language = _proto_language
+proto_language_deps = _proto_language_deps
+proto_repositories = _proto_repositories
+github_archive = _github_archive
+proto_http_archive = _proto_http_archive
+proto_dependencies = _proto_dependencies

--- a/tests/build_in_workspace_root/.bazelrc
+++ b/tests/build_in_workspace_root/.bazelrc
@@ -1,7 +1,6 @@
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
-build --incompatible_disable_legacy_cc_provider=false
 
 query --noincompatible_no_transitive_loads
 query --noincompatible_bzl_disallow_load_after_statement

--- a/tests/build_in_workspace_root/.bazelrc
+++ b/tests/build_in_workspace_root/.bazelrc
@@ -1,4 +1,3 @@
-build --incompatible_disallow_legacy_py_provider=false
 build --incompatible_disable_legacy_crosstool_fields=false
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false

--- a/tests/build_in_workspace_root/.bazelrc
+++ b/tests/build_in_workspace_root/.bazelrc
@@ -1,12 +1,9 @@
-build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
 
-query --noincompatible_no_transitive_loads
 query --noincompatible_bzl_disallow_load_after_statement
 query --noincompatible_disallow_load_labels_to_cross_package_boundaries
 
-sync --noincompatible_no_transitive_loads
 sync --noincompatible_bzl_disallow_load_after_statement
 sync --noincompatible_disallow_load_labels_to_cross_package_boundaries
 

--- a/tests/build_in_workspace_root/.bazelrc
+++ b/tests/build_in_workspace_root/.bazelrc
@@ -1,7 +1,6 @@
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
-build --incompatible_disable_crosstool_file=false
 build --incompatible_disable_legacy_cc_provider=false
 build --incompatible_disable_genrule_cc_toolchain_dependency=false
 

--- a/tests/build_in_workspace_root/.bazelrc
+++ b/tests/build_in_workspace_root/.bazelrc
@@ -1,4 +1,3 @@
-build --incompatible_disable_legacy_crosstool_fields=false
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false

--- a/tests/build_in_workspace_root/.bazelrc
+++ b/tests/build_in_workspace_root/.bazelrc
@@ -2,7 +2,6 @@ build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
 build --incompatible_disable_legacy_cc_provider=false
-build --incompatible_disable_genrule_cc_toolchain_dependency=false
 
 query --noincompatible_no_transitive_loads
 query --noincompatible_bzl_disallow_load_after_statement

--- a/tests/external_proto_library/.bazelrc
+++ b/tests/external_proto_library/.bazelrc
@@ -1,7 +1,6 @@
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
-build --incompatible_disable_legacy_cc_provider=false
 
 query --noincompatible_no_transitive_loads
 query --noincompatible_bzl_disallow_load_after_statement

--- a/tests/external_proto_library/.bazelrc
+++ b/tests/external_proto_library/.bazelrc
@@ -1,4 +1,3 @@
-build --incompatible_disallow_legacy_py_provider=false
 build --incompatible_disable_legacy_crosstool_fields=false
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false

--- a/tests/external_proto_library/.bazelrc
+++ b/tests/external_proto_library/.bazelrc
@@ -1,12 +1,9 @@
-build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
 
-query --noincompatible_no_transitive_loads
 query --noincompatible_bzl_disallow_load_after_statement
 query --noincompatible_disallow_load_labels_to_cross_package_boundaries
 
-sync --noincompatible_no_transitive_loads
 sync --noincompatible_bzl_disallow_load_after_statement
 sync --noincompatible_disallow_load_labels_to_cross_package_boundaries
 

--- a/tests/external_proto_library/.bazelrc
+++ b/tests/external_proto_library/.bazelrc
@@ -1,7 +1,6 @@
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
-build --incompatible_disable_crosstool_file=false
 build --incompatible_disable_legacy_cc_provider=false
 build --incompatible_disable_genrule_cc_toolchain_dependency=false
 

--- a/tests/external_proto_library/.bazelrc
+++ b/tests/external_proto_library/.bazelrc
@@ -1,4 +1,3 @@
-build --incompatible_disable_legacy_crosstool_fields=false
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false

--- a/tests/external_proto_library/.bazelrc
+++ b/tests/external_proto_library/.bazelrc
@@ -2,7 +2,6 @@ build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
 build --incompatible_disable_legacy_cc_provider=false
-build --incompatible_disable_genrule_cc_toolchain_dependency=false
 
 query --noincompatible_no_transitive_loads
 query --noincompatible_bzl_disallow_load_after_statement

--- a/tests/gogo/.bazelrc
+++ b/tests/gogo/.bazelrc
@@ -1,7 +1,6 @@
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
-build --incompatible_disable_legacy_cc_provider=false
 
 query --noincompatible_no_transitive_loads
 query --noincompatible_bzl_disallow_load_after_statement

--- a/tests/gogo/.bazelrc
+++ b/tests/gogo/.bazelrc
@@ -1,4 +1,3 @@
-build --incompatible_disallow_legacy_py_provider=false
 build --incompatible_disable_legacy_crosstool_fields=false
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false

--- a/tests/gogo/.bazelrc
+++ b/tests/gogo/.bazelrc
@@ -1,12 +1,9 @@
-build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
 
-query --noincompatible_no_transitive_loads
 query --noincompatible_bzl_disallow_load_after_statement
 query --noincompatible_disallow_load_labels_to_cross_package_boundaries
 
-sync --noincompatible_no_transitive_loads
 sync --noincompatible_bzl_disallow_load_after_statement
 sync --noincompatible_disallow_load_labels_to_cross_package_boundaries
 

--- a/tests/gogo/.bazelrc
+++ b/tests/gogo/.bazelrc
@@ -1,7 +1,6 @@
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
-build --incompatible_disable_crosstool_file=false
 build --incompatible_disable_legacy_cc_provider=false
 build --incompatible_disable_genrule_cc_toolchain_dependency=false
 

--- a/tests/gogo/.bazelrc
+++ b/tests/gogo/.bazelrc
@@ -1,4 +1,3 @@
-build --incompatible_disable_legacy_crosstool_fields=false
 build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false

--- a/tests/gogo/.bazelrc
+++ b/tests/gogo/.bazelrc
@@ -2,7 +2,6 @@ build --incompatible_no_transitive_loads=false
 build --incompatible_bzl_disallow_load_after_statement=false
 build --incompatible_disallow_load_labels_to_cross_package_boundaries=false
 build --incompatible_disable_legacy_cc_provider=false
-build --incompatible_disable_genrule_cc_toolchain_dependency=false
 
 query --noincompatible_no_transitive_loads
 query --noincompatible_bzl_disallow_load_after_statement


### PR DESCRIPTION
Been experimenting which incompatible flags we don't need. This seems to be the set we can remove without upgrading some deps like grpc, which itself is quite gnarly zzz

build passed in: https://travis-ci.org/vsco/rules_protobuf/builds/586057629